### PR TITLE
fix: object has no attribute metrics_domain

### DIFF
--- a/base.py
+++ b/base.py
@@ -144,7 +144,7 @@ class ComposeGenerator:
     trust_proxies: List[str] = []
 
     gateway: str
-    metrics_domain: str
+    metrics_domain: str | None = None
 
     _known_registries: Dict[str, RegistryUpstream] = []
 


### PR DESCRIPTION
This PR fixes the following runtime error
```
root@docker:~/cr-mirrors# python3 ./generate.py
Traceback (most recent call last): 
File "/root/cr-mirrors/./generate.py", line 28, in <module> 
g.add_known_registry_bulk(["docker", "ghcr", "quay", "k8s"]) 
~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "/root/cr-mirrors/base.py", line 290, in add_known_registry_bulk 
self.add_known_registry(name, name) ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^ 
File "/root/cr-mirrors/base.py", line 283, in add_known_registry 
self._add_mapping(name, upstream, domains) 
~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "/root/cr-mirrors/base.py", line 294, in _add_mapping 
svc_name, svc_conf, svc_endpoint = self._configure_cache_service( 
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ 
name, upstream 
^^^^^^^^^^^^^^ 
) 
^ 
File "/root/cr-mirrors/base.py", line 331, in _configure_cache_service

if self.metrics_domain is not None:

^^^^^^^^^^^^^^^^^^^^

AttributeError: 'ComposeGenerator' object has no attribute 'metrics_domain'

```

Now, `metrics_domain` should correctly generate the Compose YAML even when `generate.py` does not pass `metrics_domain`.